### PR TITLE
feat: expose Response Headers

### DIFF
--- a/request.go
+++ b/request.go
@@ -106,6 +106,7 @@ func (r *Request) readBody(resp *http.Response) (err error) {
 
 	r.Response.Format = r.Format
 	r.Response.Status = resp.StatusCode
+	r.Response.Header = resp.Header
 	r.Response.Raw = resp.Body
 	err = r.Response.Decode()
 

--- a/response.go
+++ b/response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
 
 	"github.com/olivere/ndjson"
 )
@@ -21,6 +22,7 @@ type Response struct {
 	RowsBeforeLimitAtLeast uint          `json:"rows_before_limit_at_least,omitempty"` // RowsBeforeLimitAtLeast is part a tinybird response.
 	Statistics             Statistics    `json:"statistics,omitempty"`                 // Statistics is part a tinybird response.
 	Status                 int           // Status is a HTTP status code, ej: 200, 400, 500 etc...
+	Header                 http.Header   // Headers contains the HTTP response headers returned by the server
 	Format                 string        // Save format setting.
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -2,6 +2,7 @@ package tinybird_test
 
 import (
 	"io"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -132,4 +133,26 @@ func TestErrorOnDecodeNDJSON(t *testing.T) {
 	err := res.Decode()
 
 	assert.NotNil(t, err)
+}
+
+func TestResponseHeader(t *testing.T) {
+	// Create a mock HTTP response
+	mockHeader := http.Header{
+		"Content-Type":    {"application/json"},
+		"X-Custom-Header": {"CustomValue"},
+	}
+	mockResponse := &http.Response{
+		Header: mockHeader,
+	}
+
+	// Create a Response object and assign the mock headers
+	response := tinybird.Response{}
+	response.Header = mockResponse.Header
+
+	// Validate Headers using testify assertions
+	assert.Equal(t, len(mockHeader), len(response.Header), "Header count should match")
+
+	for key, values := range mockHeader {
+		assert.ElementsMatch(t, values, response.Header.Values(key), "Header values should match for key: %s", key)
+	}
 }


### PR DESCRIPTION
We need to Expose the Response Headers to the consumers of the library.